### PR TITLE
Create populate commands

### DIFF
--- a/app/Console/Commands/PopulateRoutes.php
+++ b/app/Console/Commands/PopulateRoutes.php
@@ -59,7 +59,7 @@ class PopulateRoutes extends Command
                 $route->save();
                 $i++;
             } catch (QueryException $ex) {
-                $this->error('QueryException when trying to save ' . $route->id . '! ' . $ex->getMessage());
+                $this->error('QueryException when trying to save ' . $route->id . '! This could cause problems.' . "\r\n" . $ex->getMessage());
             }
         }
 

--- a/app/Console/Commands/PopulateRoutes.php
+++ b/app/Console/Commands/PopulateRoutes.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Gtfs\Parser;
+use App\Gtfs\Route;
+use Illuminate\Console\Command;
+use Illuminate\Database\QueryException;
+
+class PopulateRoutes extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'populate:routes';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Populate routes from GTFS data.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $gtfsPath = resource_path('gtfs');
+
+        // Delete old routes
+        $this->comment('Deleting old routes from database...');
+        Route::truncate();
+
+        // Parse routes GTFS data
+        $filePath = $gtfsPath . '/routes.txt';
+        $this->comment('Parsing GTFS data from "' . $filePath . '"');
+        $routes = Parser::parseRoutes($filePath);
+
+        // Load routes into database.
+        $this->comment('Saving routes into database...');
+        $i = 0;
+        foreach ($routes as $route) {
+            try {
+                $route->save();
+                $i++;
+            } catch (QueryException $ex) {
+                $this->error('QueryException when trying to save ' . $route->id . '! ' . $ex->getMessage());
+            }
+        }
+
+        $this->info('Success! Saved ' . $i . ' routes!');
+    }
+}

--- a/app/Console/Commands/PopulateShapes.php
+++ b/app/Console/Commands/PopulateShapes.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Gtfs\Parser;
+use App\Gtfs\Route;
+use App\Gtfs\Shape;
+use Illuminate\Console\Command;
+use Illuminate\Database\QueryException;
+
+class PopulateShapes extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'populate:shapes';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Populate shapes from GTFS data.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $gtfsPath = resource_path('gtfs');
+
+        // Delete old routes
+        $this->comment('Deleting old shapes from database...');
+        Shape::truncate();
+
+        // Parse GTFS data
+        $filePath = $gtfsPath . '/shapes.txt';
+        $this->comment('Parsing and saving GTFS data from "' . $filePath . '"');
+        $this->comment('This may take many minutes, depending on the size of the transit network.');
+        $shapes = Parser::parseShapes($filePath, function ($chunk) {
+            foreach ($chunk as $shapePoint) {
+                $shapePoint->save();
+            }
+        });
+
+        $this->info('Success! Saved shape points!');
+    }
+}

--- a/app/Console/Commands/PopulateShapes.php
+++ b/app/Console/Commands/PopulateShapes.php
@@ -3,10 +3,8 @@
 namespace App\Console\Commands;
 
 use App\Gtfs\Parser;
-use App\Gtfs\Route;
 use App\Gtfs\Shape;
 use Illuminate\Console\Command;
-use Illuminate\Database\QueryException;
 
 class PopulateShapes extends Command
 {

--- a/app/Console/Commands/PopulateStops.php
+++ b/app/Console/Commands/PopulateStops.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Gtfs\Parser;
+use App\Gtfs\Route;
+use App\Gtfs\Stop;
+use Illuminate\Console\Command;
+use Illuminate\Database\QueryException;
+
+class PopulateStops extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'populate:stops';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Populate stops from GTFS data.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $gtfsPath = resource_path('gtfs');
+
+        // Delete old stops
+        $this->comment('Deleting old stops from database...');
+        Stop::truncate();
+
+        // Parse stops GTFS data
+        $filePath = $gtfsPath . '/stops.txt';
+        $this->comment('Parsing GTFS data from "' . $filePath . '"');
+        $stops = Parser::parseStops($filePath);
+
+        // Load stops into database.
+        $this->comment('Saving stops into database...');
+        $i = 0;
+        foreach ($stops as $stop) {
+            try {
+                $stop->save();
+                $i++;
+            } catch (QueryException $ex) {
+                $this->error('QueryException when trying to save ' . $stop->id . '! This could cause problems.' . "\r\n" . $ex->getMessage());
+            }
+        }
+
+        $this->info('Success! Saved ' . $i . ' stops!');
+    }
+}

--- a/app/Console/Commands/PopulateStops.php
+++ b/app/Console/Commands/PopulateStops.php
@@ -3,7 +3,6 @@
 namespace App\Console\Commands;
 
 use App\Gtfs\Parser;
-use App\Gtfs\Route;
 use App\Gtfs\Stop;
 use Illuminate\Console\Command;
 use Illuminate\Database\QueryException;

--- a/app/Console/Commands/PopulateTrips.php
+++ b/app/Console/Commands/PopulateTrips.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Gtfs\Parser;
+use App\Gtfs\Route;
+use App\Gtfs\Stop;
+use App\Gtfs\Trip;
+use Illuminate\Console\Command;
+use Illuminate\Database\QueryException;
+
+class PopulateTrips extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'populate:trips';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Populate trips from GTFS data.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $gtfsPath = resource_path('gtfs');
+
+        // Delete old trips
+        $this->comment('Deleting old trips from database...');
+        Trip::truncate();
+
+        // Parse trips GTFS data
+        $filePath = $gtfsPath . '/trips.txt';
+        $this->comment('Parsing GTFS data from "' . $filePath . '"');
+        $trips = Parser::parseTrips($filePath);
+
+        // Load trips into database.
+        $this->comment('Saving trips into database...');
+        $i = 0;
+        foreach ($trips as $trip) {
+            try {
+                $trip->save();
+                $i++;
+            } catch (QueryException $ex) {
+                $this->error('QueryException when trying to save ' . $trip->id . '! This could cause problems.' . "\r\n" . $ex->getMessage());
+            }
+        }
+
+        $this->info('Success! Saved ' . $i . ' trips!');
+    }
+}

--- a/app/Console/Commands/PopulateTrips.php
+++ b/app/Console/Commands/PopulateTrips.php
@@ -3,8 +3,6 @@
 namespace App\Console\Commands;
 
 use App\Gtfs\Parser;
-use App\Gtfs\Route;
-use App\Gtfs\Stop;
 use App\Gtfs\Trip;
 use Illuminate\Console\Command;
 use Illuminate\Database\QueryException;

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -4,6 +4,7 @@ namespace App\Console;
 
 use App\Console\Commands\PopulateRoutes;
 use App\Console\Commands\PopulateShapes;
+use App\Console\Commands\PopulateStops;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 
@@ -17,6 +18,7 @@ class Kernel extends ConsoleKernel
     protected $commands = [
         PopulateRoutes::class,
         PopulateShapes::class,
+        PopulateStops::class,
     ];
 
     /**

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -5,6 +5,7 @@ namespace App\Console;
 use App\Console\Commands\PopulateRoutes;
 use App\Console\Commands\PopulateShapes;
 use App\Console\Commands\PopulateStops;
+use App\Console\Commands\PopulateTrips;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 
@@ -19,6 +20,7 @@ class Kernel extends ConsoleKernel
         PopulateRoutes::class,
         PopulateShapes::class,
         PopulateStops::class,
+        PopulateTrips::class,
     ];
 
     /**

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -3,6 +3,7 @@
 namespace App\Console;
 
 use App\Console\Commands\PopulateRoutes;
+use App\Console\Commands\PopulateShapes;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 
@@ -15,6 +16,7 @@ class Kernel extends ConsoleKernel
      */
     protected $commands = [
         PopulateRoutes::class,
+        PopulateShapes::class,
     ];
 
     /**

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -2,6 +2,7 @@
 
 namespace App\Console;
 
+use App\Console\Commands\PopulateRoutes;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 
@@ -13,7 +14,7 @@ class Kernel extends ConsoleKernel
      * @var array
      */
     protected $commands = [
-        //
+        PopulateRoutes::class,
     ];
 
     /**

--- a/app/Gtfs/Parser.php
+++ b/app/Gtfs/Parser.php
@@ -170,7 +170,7 @@ class Parser
         $shapePoints = [];
         foreach ($csv as $row) {
             $shapePoint = new Shape();
-            $shapePoint->id = intval($row[0]);
+            $shapePoint->shape_id = intval($row[0]);
             $shapePoint->sequence = intval($row[3]);
             $shapePoint->lat = doubleval($row[1]);
             $shapePoint->long = doubleval($row[2]);

--- a/app/Gtfs/Shape.php
+++ b/app/Gtfs/Shape.php
@@ -8,7 +8,8 @@ use Illuminate\Database\Eloquent\Model;
  * Shapes belong to Trips, and consist of a sequence of points. Tracing the points in order provides the path of the vehicle.
  * The points do not need to match stop locations.
  *
- * @property int $id Shape ID
+ * @property int $id Index of this shape point.
+ * @property int $shape_id Shape ID
  * @property int $sequence Number of this point in the sequence for this shape.
  * @property double $lat Latitude
  * @property double $long Longitude

--- a/app/Gtfs/Stop.php
+++ b/app/Gtfs/Stop.php
@@ -27,5 +27,5 @@ use Illuminate\Database\Eloquent\Model;
  */
 class Stop extends Model
 {
-    public $timezones = false;
+    public $timestamps = false;
 }

--- a/database/migrations/2016_10_15_125029_rename_distance_traveled_column_in_shapes_table.php
+++ b/database/migrations/2016_10_15_125029_rename_distance_traveled_column_in_shapes_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class RenameDistanceTraveledColumnInShapesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('shapes', function (Blueprint $table) {
+            $table->renameColumn('distance_traveled', 'distance');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('shapes', function (Blueprint $table) {
+            $table->renameColumn('distance', 'distance_traveled');
+        });
+    }
+}

--- a/database/migrations/2016_10_15_130257_add_index_column_to_shapes_table.php
+++ b/database/migrations/2016_10_15_130257_add_index_column_to_shapes_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddIndexColumnToShapesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('shapes', function (Blueprint $table) {
+            $table->integer('shape_id')->after('id');
+            $table->increments('id')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('shapes', function (Blueprint $table) {
+            $table->dropColumn('shape_id');
+            $table->integer('id')->change();
+        });
+    }
+}


### PR DESCRIPTION
Added commands to populate the database with GTFS data.
## Commands
- `php artisan populate:routes` - Populate the routes table with data from routes.txt.
- `php artisan populate:shapes` - Populate the shapes table with data from shapes.txt. Note this command is very slow.
- `php artisan populate:stops` - Populate the stops table with data from stops.txt.
- `php artisan populate:trips` - Populate the trips table with data from trips.txt. A little slow.
